### PR TITLE
공지사항 CRUD + AWS S3 기능 모듈화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -72,9 +72,8 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // AWS S3
-    implementation platform('software.amazon.awssdk:bom:2.21.1')
-    implementation 'software.amazon.awssdk:s3'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.0'
+    implementation platform('software.amazon.awssdk:bom:2.21.1') // AWS SDK 모듈 간의 버전 호환성을 관리
+    implementation 'software.amazon.awssdk:s3' // AWS S3의 핵심 SDK
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -70,6 +70,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // AWS S3
+    implementation platform('software.amazon.awssdk:bom:2.21.1')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/redbox/domain/article/exception/ArticleNotFoundException.java
+++ b/backend/src/main/java/com/redbox/domain/article/exception/ArticleNotFoundException.java
@@ -5,6 +5,6 @@ import com.redbox.global.exception.ErrorCode;
 
 public class ArticleNotFoundException extends BusinessException {
     public ArticleNotFoundException() {
-        super(ErrorCode.FAILED_TO_FIND_ARTICLE);
+        super(ErrorCode.FAIL_TO_FIND_ARTICLE);
     }
 }

--- a/backend/src/main/java/com/redbox/domain/attach/dto/AttachFileResponse.java
+++ b/backend/src/main/java/com/redbox/domain/attach/dto/AttachFileResponse.java
@@ -1,0 +1,17 @@
+package com.redbox.domain.attach.dto;
+
+import com.redbox.domain.attach.entity.AttachFile;
+import lombok.Getter;
+
+@Getter
+public class AttachFileResponse {
+    private final Long fileNo;
+    private final String originFilename;
+    private final String filename;
+
+    public AttachFileResponse(AttachFile file) {
+        this.fileNo = file.getId();
+        this.originFilename = file.getOriginalFilename();
+        this.filename = file.getNewFilename();
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/attach/entity/AttachFile.java
+++ b/backend/src/main/java/com/redbox/domain/attach/entity/AttachFile.java
@@ -1,0 +1,42 @@
+package com.redbox.domain.attach.entity;
+
+import com.redbox.domain.notice.entity.Notice;
+import com.redbox.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "attach_files")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttachFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attach_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    // 아직 request 와 merge 하기 전
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "request_id")
+//    private Request request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    private String originalFilename;
+    private String newFilename;
+    private String attachFileType;
+
+    // 연관 관계 편의 메서드를 위한 setter 메서드
+    @SuppressWarnings("lombok")
+    public void setNotice(Notice notice) {
+        this.notice = notice;
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/attach/entity/AttachFile.java
+++ b/backend/src/main/java/com/redbox/domain/attach/entity/AttachFile.java
@@ -33,15 +33,13 @@ public class AttachFile extends BaseEntity {
 
     private String originalFilename;
     private String newFilename;
-    private String fileUrl;
 
     @Builder
-    public AttachFile(Category category, Notice notice, String originalFilename, String newFilename, String fileUrl) {
+    public AttachFile(Category category, Notice notice, String originalFilename, String newFilename) {
         this.category = category;
         this.notice = notice;
         this.originalFilename = originalFilename;
         this.newFilename = newFilename;
-        this.fileUrl = fileUrl;
     }
 
     // 연관 관계 편의 메서드를 위한 setter 메서드

--- a/backend/src/main/java/com/redbox/domain/attach/entity/AttachFile.java
+++ b/backend/src/main/java/com/redbox/domain/attach/entity/AttachFile.java
@@ -4,6 +4,7 @@ import com.redbox.domain.notice.entity.Notice;
 import com.redbox.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,7 +33,16 @@ public class AttachFile extends BaseEntity {
 
     private String originalFilename;
     private String newFilename;
-    private String attachFileType;
+    private String fileUrl;
+
+    @Builder
+    public AttachFile(Category category, Notice notice, String originalFilename, String newFilename, String fileUrl) {
+        this.category = category;
+        this.notice = notice;
+        this.originalFilename = originalFilename;
+        this.newFilename = newFilename;
+        this.fileUrl = fileUrl;
+    }
 
     // 연관 관계 편의 메서드를 위한 setter 메서드
     @SuppressWarnings("lombok")

--- a/backend/src/main/java/com/redbox/domain/attach/entity/Category.java
+++ b/backend/src/main/java/com/redbox/domain/attach/entity/Category.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Category {
 
-    REQUEST("요청게시판"), NOTICE("공지사항");
+    REQUEST("요청게시판","request"), NOTICE("공지사항","notice");
 
     private final String text;
+    private final String path; // s3 디렉토리 구조에 사용
 }

--- a/backend/src/main/java/com/redbox/domain/attach/entity/Category.java
+++ b/backend/src/main/java/com/redbox/domain/attach/entity/Category.java
@@ -1,0 +1,13 @@
+package com.redbox.domain.attach.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+
+    REQUEST("요청게시판"), NOTICE("공지사항");
+
+    private final String text;
+}

--- a/backend/src/main/java/com/redbox/domain/attach/exception/AttachFileNotFoundException.java
+++ b/backend/src/main/java/com/redbox/domain/attach/exception/AttachFileNotFoundException.java
@@ -1,0 +1,10 @@
+package com.redbox.domain.attach.exception;
+
+import com.redbox.global.exception.BusinessException;
+import com.redbox.global.exception.ErrorCode;
+
+public class AttachFileNotFoundException extends BusinessException {
+    public AttachFileNotFoundException() {
+        super(ErrorCode.FAIL_TO_FIND_ATTACHFILE);
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/attach/exception/FileNotBelongException.java
+++ b/backend/src/main/java/com/redbox/domain/attach/exception/FileNotBelongException.java
@@ -1,0 +1,11 @@
+package com.redbox.domain.attach.exception;
+
+import com.redbox.global.exception.BusinessException;
+import com.redbox.global.exception.ErrorCode;
+
+public class FileNotBelongException extends BusinessException {
+    public FileNotBelongException() {
+        super(ErrorCode.NOT_BELONG_TO_FILE);
+    }
+}
+

--- a/backend/src/main/java/com/redbox/domain/attach/exception/NullAttachFileException.java
+++ b/backend/src/main/java/com/redbox/domain/attach/exception/NullAttachFileException.java
@@ -1,0 +1,10 @@
+package com.redbox.domain.attach.exception;
+
+import com.redbox.global.exception.BusinessException;
+import com.redbox.global.exception.ErrorCode;
+
+public class NullAttachFileException extends BusinessException {
+    public NullAttachFileException() {
+        super(ErrorCode.INVALID_ATTACHFILE);
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/attach/repository/AttachFileRepository.java
+++ b/backend/src/main/java/com/redbox/domain/attach/repository/AttachFileRepository.java
@@ -1,0 +1,10 @@
+package com.redbox.domain.attach.repository;
+
+import com.redbox.domain.attach.entity.AttachFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AttachFileRepository extends JpaRepository<AttachFile, Long> {
+
+}

--- a/backend/src/main/java/com/redbox/domain/attach/service/AttachFileService.java
+++ b/backend/src/main/java/com/redbox/domain/attach/service/AttachFileService.java
@@ -1,0 +1,47 @@
+package com.redbox.domain.attach.service;
+
+import com.redbox.domain.attach.entity.AttachFile;
+import com.redbox.domain.attach.exception.AttachFileNotFoundException;
+import com.redbox.domain.attach.exception.FileNotBelongException;
+import com.redbox.domain.attach.repository.AttachFileRepository;
+import com.redbox.global.infra.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AttachFileService {
+
+    private final AttachFileRepository attachFileRepository;
+    private final S3Service s3Service;
+
+    public String getFileDownloadUrl(Long postId, Long fileId) {
+        AttachFile attachFile = attachFileRepository.findById(fileId)
+                .orElseThrow(AttachFileNotFoundException::new);
+
+        validateFileOwnership(attachFile, postId);
+
+        // PreSignedURL 생성
+        return s3Service.generatePresignedUrl(
+                attachFile.getCategory(),
+                postId,
+                attachFile.getNewFilename(),
+                attachFile.getOriginalFilename()
+        );
+    }
+
+    private void validateFileOwnership(AttachFile attachFile, Long postId) {
+        boolean isValid = switch (attachFile.getCategory()) {
+            case NOTICE -> attachFile.getNotice() != null &&
+                    attachFile.getNotice().getId().equals(postId);
+            // Request 기능과 합쳐지면 수정
+            case REQUEST -> true;
+//                    attachFile.getRequest() != null &&
+//                    attachFile.getRequest().getId().equals(postId);
+        };
+
+        if (!isValid) {
+            throw new FileNotBelongException();
+        }
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/attach/service/AttachFileService.java
+++ b/backend/src/main/java/com/redbox/domain/attach/service/AttachFileService.java
@@ -1,12 +1,19 @@
 package com.redbox.domain.attach.service;
 
+import com.redbox.domain.attach.dto.AttachFileResponse;
 import com.redbox.domain.attach.entity.AttachFile;
+import com.redbox.domain.attach.entity.Category;
 import com.redbox.domain.attach.exception.AttachFileNotFoundException;
 import com.redbox.domain.attach.exception.FileNotBelongException;
 import com.redbox.domain.attach.repository.AttachFileRepository;
+import com.redbox.domain.attach.strategy.FileAttachStrategy;
+import com.redbox.domain.attach.strategy.FileAttachStrategyFactory;
+import com.redbox.domain.notice.repository.NoticeRepository;
 import com.redbox.global.infra.s3.S3Service;
+import com.redbox.global.util.FileUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +21,8 @@ public class AttachFileService {
 
     private final AttachFileRepository attachFileRepository;
     private final S3Service s3Service;
+    private final NoticeRepository noticeRepository;
+    private final FileAttachStrategyFactory fileAttachStrategyFactory;
 
     public String getFileDownloadUrl(Long postId, Long fileId) {
         AttachFile attachFile = attachFileRepository.findById(fileId)
@@ -43,5 +52,20 @@ public class AttachFileService {
         if (!isValid) {
             throw new FileNotBelongException();
         }
+    }
+
+    public AttachFileResponse addFile(Category category, Long postId, MultipartFile file) {
+        // S3에 파일 업로드
+        String newFilename = FileUtils.generateNewFilename();
+        String extension = FileUtils.getExtension(file);
+        String fullFilename = newFilename + "." + extension;
+        s3Service.uploadFile(file, category, postId, fullFilename);
+
+        // 카테고리에 맞는 전략 사용
+        FileAttachStrategy strategy = fileAttachStrategyFactory.getStrategy(category);
+        AttachFile attachFile = strategy.attach(postId, file.getOriginalFilename(), fullFilename);
+        attachFileRepository.save(attachFile);
+
+        return new AttachFileResponse(attachFile);
     }
 }

--- a/backend/src/main/java/com/redbox/domain/attach/strategy/FileAttachStrategy.java
+++ b/backend/src/main/java/com/redbox/domain/attach/strategy/FileAttachStrategy.java
@@ -1,0 +1,7 @@
+package com.redbox.domain.attach.strategy;
+
+import com.redbox.domain.attach.entity.AttachFile;
+
+public interface FileAttachStrategy {
+    AttachFile attach(Long postId, String originalFilename, String newFilename);
+}

--- a/backend/src/main/java/com/redbox/domain/attach/strategy/FileAttachStrategyFactory.java
+++ b/backend/src/main/java/com/redbox/domain/attach/strategy/FileAttachStrategyFactory.java
@@ -1,0 +1,32 @@
+package com.redbox.domain.attach.strategy;
+
+import com.redbox.domain.attach.entity.Category;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class FileAttachStrategyFactory {
+
+    private final Map<Category, FileAttachStrategy> strategies;
+
+    public FileAttachStrategyFactory(List<FileAttachStrategy> strategyList) {
+        strategies = Map.of(
+                Category.NOTICE, findStrategy(strategyList, NoticeFileStrategy.class)
+        );
+    }
+
+    // 전략 리스트에서 특정 타입의 전략을 찾는 private 메서드
+    private FileAttachStrategy findStrategy(List<FileAttachStrategy> strategies,
+                                            Class<? extends FileAttachStrategy> strategyClass) {
+        return strategies.stream()
+                .filter(strategyClass::isInstance)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("해당 전략이 설정되지 않았습니다: " + strategyClass.getSimpleName()));
+    }
+
+    public FileAttachStrategy getStrategy(Category category) {
+        return strategies.get(category);
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/attach/strategy/NoticeFileStrategy.java
+++ b/backend/src/main/java/com/redbox/domain/attach/strategy/NoticeFileStrategy.java
@@ -1,0 +1,29 @@
+package com.redbox.domain.attach.strategy;
+
+import com.redbox.domain.attach.entity.AttachFile;
+import com.redbox.domain.attach.entity.Category;
+import com.redbox.domain.notice.entity.Notice;
+import com.redbox.domain.notice.exception.NoticeNotFoundException;
+import com.redbox.domain.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeFileStrategy implements FileAttachStrategy {
+
+    private final NoticeRepository noticeRepository;
+
+    @Override
+    public AttachFile attach(Long postId, String originalFilename, String newFilename) {
+        Notice notice = noticeRepository.findById(postId)
+                .orElseThrow(NoticeNotFoundException::new);
+
+        return AttachFile.builder()
+                .category(Category.NOTICE)
+                .notice(notice)
+                .originalFilename(originalFilename)
+                .newFilename(newFilename)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -1,15 +1,20 @@
 package com.redbox.domain.notice.controller;
 
+import com.redbox.domain.notice.dto.CreateNoticeRequest;
 import com.redbox.domain.notice.dto.NoticeListResponse;
 import com.redbox.domain.notice.dto.NoticeResponse;
 import com.redbox.domain.notice.service.NoticeService;
 import com.redbox.global.entity.PageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +33,23 @@ public class NoticeController {
     @GetMapping("/notices/{noticeId}")
     public ResponseEntity<NoticeResponse> getNotice(@PathVariable Long noticeId) {
         return ResponseEntity.ok(noticeService.getNotice(noticeId));
+    }
+
+    @PostMapping(value = "/notices", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<NoticeResponse> createNotice(
+            @RequestPart(value = "request") @Valid CreateNoticeRequest request,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files
+    ) {
+        NoticeResponse response = noticeService.createNotice(request, files);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(response.getNoticeNo())
+                .toUri();
+
+        return ResponseEntity
+                .created(location)
+                .body(response);
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -1,11 +1,13 @@
 package com.redbox.domain.notice.controller;
 
 import com.redbox.domain.notice.dto.NoticeListResponse;
+import com.redbox.domain.notice.dto.NoticeResponse;
 import com.redbox.domain.notice.service.NoticeService;
 import com.redbox.global.entity.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +23,10 @@ public class NoticeController {
             @RequestParam(defaultValue = "10") int size
     ) {
         return ResponseEntity.ok(noticeService.getNotices(page, size));
+    }
+
+    @GetMapping("/notices/{noticeId}")
+    public ResponseEntity<NoticeResponse> getNotice(@PathVariable Long noticeId) {
+        return ResponseEntity.ok(noticeService.getNotice(noticeId));
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -87,4 +87,12 @@ public class NoticeController {
     ) {
         return ResponseEntity.ok(attachFileService.addFile(Category.NOTICE, noticeId, file));
     }
+
+    @DeleteMapping("/notices/{noticeId}/files/{fileId}")
+    public ResponseEntity<Void> removeFile(
+            @PathVariable Long noticeId,
+            @PathVariable Long fileId) {
+        attachFileService.removeFile(Category.NOTICE, noticeId, fileId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -1,5 +1,7 @@
 package com.redbox.domain.notice.controller;
 
+import com.redbox.domain.attach.dto.AttachFileResponse;
+import com.redbox.domain.attach.entity.Category;
 import com.redbox.domain.attach.service.AttachFileService;
 import com.redbox.domain.notice.dto.CreateNoticeRequest;
 import com.redbox.domain.notice.dto.NoticeListResponse;
@@ -76,5 +78,13 @@ public class NoticeController {
             @PathVariable Long noticeId,
             @PathVariable Long fileId) {
         return ResponseEntity.ok(attachFileService.getFileDownloadUrl(noticeId, fileId));
+    }
+
+    @PostMapping(value = "/notices/{noticeId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<AttachFileResponse> addFile(
+            @PathVariable Long noticeId,
+            @RequestPart(value = "file") MultipartFile file
+    ) {
+        return ResponseEntity.ok(attachFileService.addFile(Category.NOTICE, noticeId, file));
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -1,0 +1,25 @@
+package com.redbox.domain.notice.controller;
+
+import com.redbox.domain.notice.dto.NoticeListResponse;
+import com.redbox.domain.notice.service.NoticeService;
+import com.redbox.global.entity.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("/notices")
+    public ResponseEntity<PageResponse<NoticeListResponse>> getNotices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(noticeService.getNotices(page, size));
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -4,6 +4,7 @@ import com.redbox.domain.attach.service.AttachFileService;
 import com.redbox.domain.notice.dto.CreateNoticeRequest;
 import com.redbox.domain.notice.dto.NoticeListResponse;
 import com.redbox.domain.notice.dto.NoticeResponse;
+import com.redbox.domain.notice.dto.UpdateNoticeRequest;
 import com.redbox.domain.notice.service.NoticeService;
 import com.redbox.global.entity.PageResponse;
 import jakarta.validation.Valid;
@@ -53,6 +54,15 @@ public class NoticeController {
         return ResponseEntity
                 .created(location)
                 .body(response);
+    }
+
+    @PutMapping("/notices/{noticeId}")
+    public ResponseEntity<NoticeResponse> updateNotice(
+            @PathVariable Long noticeId,
+            @RequestBody @Valid UpdateNoticeRequest request) {
+        return ResponseEntity
+                .ok()
+                .body(noticeService.updateNotice(noticeId, request));
     }
 
     @GetMapping("/notices/{noticeId}/files/{fileId}")

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -65,6 +65,12 @@ public class NoticeController {
                 .body(noticeService.updateNotice(noticeId, request));
     }
 
+    @DeleteMapping("/notices/{noticeId}")
+    public ResponseEntity<Void> deleteNotice(@PathVariable Long noticeId) {
+        noticeService.deleteNotice(noticeId);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/notices/{noticeId}/files/{fileId}")
     public ResponseEntity<String> downloadFile(
             @PathVariable Long noticeId,

--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -1,5 +1,6 @@
 package com.redbox.domain.notice.controller;
 
+import com.redbox.domain.attach.service.AttachFileService;
 import com.redbox.domain.notice.dto.CreateNoticeRequest;
 import com.redbox.domain.notice.dto.NoticeListResponse;
 import com.redbox.domain.notice.dto.NoticeResponse;
@@ -21,6 +22,7 @@ import java.util.List;
 public class NoticeController {
 
     private final NoticeService noticeService;
+    private final AttachFileService attachFileService;
 
     @GetMapping("/notices")
     public ResponseEntity<PageResponse<NoticeListResponse>> getNotices(
@@ -51,5 +53,12 @@ public class NoticeController {
         return ResponseEntity
                 .created(location)
                 .body(response);
+    }
+
+    @GetMapping("/notices/{noticeId}/files/{fileId}")
+    public ResponseEntity<String> downloadFile(
+            @PathVariable Long noticeId,
+            @PathVariable Long fileId) {
+        return ResponseEntity.ok(attachFileService.getFileDownloadUrl(noticeId, fileId));
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/dto/CreateNoticeRequest.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/CreateNoticeRequest.java
@@ -1,0 +1,16 @@
+package com.redbox.domain.notice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateNoticeRequest {
+
+    @NotBlank(message = "제목을 입력해주세요.")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+}

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeListResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeListResponse.java
@@ -1,0 +1,28 @@
+package com.redbox.domain.notice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeListResponse {
+
+    private Long noticeNo;
+    private String title;
+    private LocalDate createdDate;
+    private String writer;
+    private int views;
+    private boolean hasAttachFiles;
+
+    public NoticeListResponse(Long noticeNo, String title, LocalDateTime createdDate, String writer, int views, boolean hasAttachFiles) {
+        this.noticeNo = noticeNo;
+        this.title = title;
+        this.createdDate = createdDate.toLocalDate();
+        this.writer = writer;
+        this.views = views;
+        this.hasAttachFiles = hasAttachFiles;
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -22,9 +22,13 @@ public class NoticeResponse {
 
     @Getter
     private static class AttachFileResponse {
+        private final Long fileNo;
+        private final String originFilename;
         private final String filename;
 
         public AttachFileResponse(AttachFile file) {
+            this.fileNo = file.getId();
+            this.originFilename = file.getOriginalFilename();
             this.filename = file.getNewFilename();
         }
     }

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -25,9 +25,7 @@ public class NoticeResponse {
         private final String filename;
 
         public AttachFileResponse(AttachFile file) {
-            this.filename = file.getNewFilename() +
-                    '.' +
-                    file.getAttachFileType();
+            this.filename = file.getNewFilename();
         }
     }
 

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -2,11 +2,13 @@ package com.redbox.domain.notice.dto;
 
 import com.redbox.domain.attach.entity.AttachFile;
 import com.redbox.domain.notice.entity.Notice;
+import com.redbox.domain.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @NoArgsConstructor
@@ -38,7 +40,9 @@ public class NoticeResponse {
         this.title = notice.getNoticeTitle();
         this.content = notice.getNoticeContent();
         this.createdDate = notice.getCreatedAt().toLocalDate();
-        this.writer = notice.getUser().getName();
+        this.writer = Optional.ofNullable(notice.getUser())
+                .map(User::getName)
+                .orElse("Unknown");
         this.views = notice.getNoticeHits();
         this.attachFileResponses = notice.getAttachFiles()
                 .stream().map(AttachFileResponse::new).toList();

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -1,0 +1,25 @@
+package com.redbox.domain.notice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class NoticeResponse {
+
+    private Long noticeNo;
+    private String title;
+    private String content;
+    private LocalDate createdDate;
+    private String writer;
+    private int views;
+    private List<AttachFileResponse> attachFileResponses;
+
+    @Getter
+    private static class AttachFileResponse {
+        private String filename;
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -1,5 +1,7 @@
 package com.redbox.domain.notice.dto;
 
+import com.redbox.domain.attach.entity.AttachFile;
+import com.redbox.domain.notice.entity.Notice;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,6 +22,24 @@ public class NoticeResponse {
 
     @Getter
     private static class AttachFileResponse {
-        private String filename;
+        private final String filename;
+
+        public AttachFileResponse(AttachFile file) {
+            this.filename = file.getNewFilename() +
+                    '.' +
+                    file.getAttachFileType();
+        }
+    }
+
+    public NoticeResponse(Notice notice, String writer) {
+        this.noticeNo = notice.getId();
+        this.title = notice.getNoticeTitle();
+        this.content = notice.getNoticeContent();
+        this.createdDate = notice.getCreatedAt().toLocalDate();
+        this.writer = writer;
+        this.views = notice.getNoticeHits();
+        this.attachFileResponses = notice.getAttachFiles()
+                .stream().map(AttachFileResponse::new).toList();
+
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -1,39 +1,24 @@
 package com.redbox.domain.notice.dto;
 
-import com.redbox.domain.attach.entity.AttachFile;
+import com.redbox.domain.attach.dto.AttachFileResponse;
 import com.redbox.domain.notice.entity.Notice;
 import com.redbox.domain.user.entity.User;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 @Getter
-@NoArgsConstructor
 public class NoticeResponse {
 
-    private Long noticeNo;
-    private String title;
-    private String content;
-    private LocalDate createdDate;
-    private String writer;
-    private int views;
-    private List<AttachFileResponse> attachFileResponses;
-
-    @Getter
-    private static class AttachFileResponse {
-        private final Long fileNo;
-        private final String originFilename;
-        private final String filename;
-
-        public AttachFileResponse(AttachFile file) {
-            this.fileNo = file.getId();
-            this.originFilename = file.getOriginalFilename();
-            this.filename = file.getNewFilename();
-        }
-    }
+    private final Long noticeNo;
+    private final String title;
+    private final String content;
+    private final LocalDate createdDate;
+    private final String writer;
+    private final int views;
+    private final List<AttachFileResponse> attachFileResponses;
 
     public NoticeResponse(Notice notice) {
         this.noticeNo = notice.getId();

--- a/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/NoticeResponse.java
@@ -33,12 +33,12 @@ public class NoticeResponse {
         }
     }
 
-    public NoticeResponse(Notice notice, String writer) {
+    public NoticeResponse(Notice notice) {
         this.noticeNo = notice.getId();
         this.title = notice.getNoticeTitle();
         this.content = notice.getNoticeContent();
         this.createdDate = notice.getCreatedAt().toLocalDate();
-        this.writer = writer;
+        this.writer = notice.getUser().getName();
         this.views = notice.getNoticeHits();
         this.attachFileResponses = notice.getAttachFiles()
                 .stream().map(AttachFileResponse::new).toList();

--- a/backend/src/main/java/com/redbox/domain/notice/dto/UpdateNoticeRequest.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/UpdateNoticeRequest.java
@@ -1,0 +1,16 @@
+package com.redbox.domain.notice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNoticeRequest {
+
+    @NotBlank(message = "제목을 입력해주세요.")
+    private String title;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+}

--- a/backend/src/main/java/com/redbox/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/redbox/domain/notice/entity/Notice.java
@@ -5,6 +5,7 @@ import com.redbox.domain.attach.exception.NullAttachFileException;
 import com.redbox.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,14 @@ public class Notice extends BaseEntity {
 
     @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AttachFile> attachFiles = new ArrayList<>();
+
+    @Builder
+    public Notice(Long userId, String noticeTitle, String noticeContent, int noticeHits) {
+        this.userId = userId;
+        this.noticeTitle = noticeTitle;
+        this.noticeContent = noticeContent;
+        this.noticeHits = noticeHits;
+    }
 
     // 연관관계 편의 메서드
     // 비즈니스 로직 상 글 기준으로 움직이기 때문에 여기에 선언

--- a/backend/src/main/java/com/redbox/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/redbox/domain/notice/entity/Notice.java
@@ -1,0 +1,63 @@
+package com.redbox.domain.notice.entity;
+
+import com.redbox.domain.attach.entity.AttachFile;
+import com.redbox.domain.attach.exception.NullAttachFileException;
+import com.redbox.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "notices")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
+    private Long id;
+
+    private Long userId;
+    private String noticeTitle;
+
+    @Lob
+    private String noticeContent;
+
+    private int noticeHits;
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AttachFile> attachFiles = new ArrayList<>();
+
+    // 연관관계 편의 메서드
+    // 비즈니스 로직 상 글 기준으로 움직이기 때문에 여기에 선언
+    public void addAttachFiles(AttachFile attachFile) {
+        checkNullAttachFile(attachFile);
+        if (isDuplicateAttachFile(attachFile)) return;
+
+        this.attachFiles.add(attachFile);
+        attachFile.setNotice(this);
+    }
+
+    public void removeAttachFiles(AttachFile attachFile) {
+        checkNullAttachFile(attachFile);
+        if (isDuplicateAttachFile(attachFile)) return;
+
+        this.attachFiles.remove(attachFile);
+        attachFile.setNotice(null);
+    }
+
+    private void checkNullAttachFile(AttachFile attachFile) {
+        if (attachFile == null) {
+            throw new NullAttachFileException();
+        }
+    }
+
+    private boolean isDuplicateAttachFile(AttachFile attachFile) {
+        return this.attachFiles.contains(attachFile);
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/redbox/domain/notice/entity/Notice.java
@@ -2,6 +2,8 @@ package com.redbox.domain.notice.entity;
 
 import com.redbox.domain.attach.entity.AttachFile;
 import com.redbox.domain.attach.exception.NullAttachFileException;
+import com.redbox.domain.notice.dto.UpdateNoticeRequest;
+import com.redbox.domain.user.entity.User;
 import com.redbox.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -23,7 +25,9 @@ public class Notice extends BaseEntity {
     @Column(name = "notice_id")
     private Long id;
 
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
     private String noticeTitle;
 
     @Lob
@@ -35,8 +39,8 @@ public class Notice extends BaseEntity {
     private List<AttachFile> attachFiles = new ArrayList<>();
 
     @Builder
-    public Notice(Long userId, String noticeTitle, String noticeContent, int noticeHits) {
-        this.userId = userId;
+    public Notice(User user, String noticeTitle, String noticeContent, int noticeHits) {
+        this.user = user;
         this.noticeTitle = noticeTitle;
         this.noticeContent = noticeContent;
         this.noticeHits = noticeHits;
@@ -68,5 +72,10 @@ public class Notice extends BaseEntity {
 
     private boolean isDuplicateAttachFile(AttachFile attachFile) {
         return this.attachFiles.contains(attachFile);
+    }
+
+    public void updateNotice(UpdateNoticeRequest request) {
+        this.noticeTitle = request.getTitle();
+        this.noticeContent = request.getContent();
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/exception/NoticeNotFoundException.java
+++ b/backend/src/main/java/com/redbox/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.redbox.domain.notice.exception;
+
+import com.redbox.global.exception.BusinessException;
+import com.redbox.global.exception.ErrorCode;
+
+public class NoticeNotFoundException extends BusinessException {
+    public NoticeNotFoundException() {
+        super(ErrorCode.FAIL_TO_FIND_NOTICE);
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeQueryRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeQueryRepository.java
@@ -29,11 +29,11 @@ public class NoticeQueryRepository {
                         notice.id.as("noticeNo"),
                         notice.noticeTitle.as("title"),
                         notice.createdAt.as("createdDate"),
-                        user.name.as("writer"),
+                        user.name.coalesce("Unknown").as("writer"),
                         notice.noticeHits.as("views"),
                         notice.attachFiles.isNotEmpty().as("hasAttachFiles")
                         )).from(notice)
-                        .leftJoin(user).on(notice.userId.eq(user.id))
+                        .leftJoin(notice.user, user)
                         .orderBy(notice.createdAt.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeQueryRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeQueryRepository.java
@@ -1,0 +1,51 @@
+package com.redbox.domain.notice.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.redbox.domain.notice.dto.NoticeListResponse;
+import com.redbox.domain.notice.entity.QNotice;
+import com.redbox.domain.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QNotice notice = QNotice.notice;
+    private final QUser user = QUser.user;
+
+    public Page<NoticeListResponse> findNotices(Pageable pageable) {
+        // 데이터 조회
+        List<NoticeListResponse> response =
+                queryFactory.select(Projections.constructor(NoticeListResponse.class,
+                        notice.id.as("noticeNo"),
+                        notice.noticeTitle.as("title"),
+                        notice.createdAt.as("createdDate"),
+                        user.name.as("writer"),
+                        notice.noticeHits.as("views"),
+                        notice.attachFiles.isNotEmpty().as("hasAttachFiles")
+                        )).from(notice)
+                        .leftJoin(user).on(notice.userId.eq(user.id))
+                        .orderBy(notice.createdAt.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        // 전체 카운트 조회
+        long total = Optional.ofNullable(
+                queryFactory.select(notice.count())
+                .from(notice)
+                .fetchOne()
+            ).orElse(0L);
+
+        return new PageImpl<>(response, pageable, total);
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,10 @@
+package com.redbox.domain.notice.repository;
+
+import com.redbox.domain.notice.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+}

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
@@ -2,9 +2,20 @@ package com.redbox.domain.notice.repository;
 
 import com.redbox.domain.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
+    @Query("select n from Notice n left join fetch n.attachFiles where n.id = :noticeId")
+    Optional<Notice> findWithAttachFilesById(@Param("noticeId") Long id);
+
+    @Modifying
+    @Query("UPDATE Notice n SET n.noticeHits = n.noticeHits + 1 WHERE n.id = :id")
+    void increaseHit(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
@@ -12,10 +12,18 @@ import java.util.Optional;
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    @Query("select n from Notice n left join fetch n.attachFiles where n.id = :noticeId")
-    Optional<Notice> findWithAttachFilesById(@Param("noticeId") Long id);
-
     @Modifying
     @Query("UPDATE Notice n SET n.noticeHits = n.noticeHits + 1 WHERE n.id = :id")
     void increaseHit(@Param("id") Long id);
+
+    @Query("select n from Notice n" +
+            " left join fetch n.attachFiles af" +
+            " left join fetch n.user u" +
+            " where n.id = :noticeId")
+    Optional<Notice> findForDetail(@Param("noticeId") Long id);
+
+    @Query("select n from Notice n" +
+            " left join fetch n.user u" +
+            " where n.id = :noticeId")
+    Optional<Notice> findForUpdate(@Param("noticeId") Long id);
 }

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
@@ -26,4 +26,9 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             " left join fetch n.user u" +
             " where n.id = :noticeId")
     Optional<Notice> findForUpdate(@Param("noticeId") Long id);
+
+    @Query("select n from Notice n" +
+            " left join fetch n.attachFiles af" +
+            " where n.id = :noticeId")
+    Optional<Notice> findForDelete(@Param("noticeId") Long id);
 }

--- a/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
@@ -1,13 +1,18 @@
 package com.redbox.domain.notice.service;
 
 import com.redbox.domain.notice.dto.NoticeListResponse;
+import com.redbox.domain.notice.dto.NoticeResponse;
+import com.redbox.domain.notice.entity.Notice;
+import com.redbox.domain.notice.exception.NoticeNotFoundException;
 import com.redbox.domain.notice.repository.NoticeQueryRepository;
 import com.redbox.domain.notice.repository.NoticeRepository;
+import com.redbox.domain.user.repository.UserRepository;
 import com.redbox.global.entity.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +20,26 @@ public class NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final NoticeQueryRepository noticeQueryRepository;
+    private final UserRepository userRepository;
 
     public PageResponse<NoticeListResponse> getNotices(int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
         return new PageResponse<>(noticeQueryRepository.findNotices(pageable));
+    }
+
+    @Transactional
+    public NoticeResponse getNotice(Long noticeId) {
+        // 조회수 증가
+        noticeRepository.increaseHit(noticeId);
+
+        // 공지사항 조회
+        Notice notice = noticeRepository.findWithAttachFilesById(noticeId)
+                .orElseThrow(NoticeNotFoundException::new);
+
+        // 글쓴이 조회
+        String writer = userRepository.findNameById(notice.getUserId())
+                .orElse("Unknown");
+
+        return new NoticeResponse(notice, writer);
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
@@ -1,0 +1,23 @@
+package com.redbox.domain.notice.service;
+
+import com.redbox.domain.notice.dto.NoticeListResponse;
+import com.redbox.domain.notice.repository.NoticeQueryRepository;
+import com.redbox.domain.notice.repository.NoticeRepository;
+import com.redbox.global.entity.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeQueryRepository noticeQueryRepository;
+
+    public PageResponse<NoticeListResponse> getNotices(int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return new PageResponse<>(noticeQueryRepository.findNotices(pageable));
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
@@ -93,4 +93,17 @@ public class NoticeService {
 
         return new NoticeResponse(notice);
     }
+
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findForDelete(noticeId)
+                .orElseThrow(NoticeNotFoundException::new);
+
+        // 파일 삭제
+        for (AttachFile attachFile : notice.getAttachFiles()) {
+            s3Service.deleteFile(attachFile.getCategory(), notice.getId(), attachFile.getNewFilename());
+        }
+
+        noticeRepository.delete(notice);
+    }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
@@ -2,12 +2,11 @@ package com.redbox.domain.notice.service;
 
 import com.redbox.domain.attach.entity.AttachFile;
 import com.redbox.domain.attach.entity.Category;
-import com.redbox.domain.attach.exception.AttachFileNotFoundException;
-import com.redbox.domain.attach.exception.FileNotBelongException;
 import com.redbox.domain.attach.repository.AttachFileRepository;
 import com.redbox.domain.notice.dto.CreateNoticeRequest;
 import com.redbox.domain.notice.dto.NoticeListResponse;
 import com.redbox.domain.notice.dto.NoticeResponse;
+import com.redbox.domain.notice.dto.UpdateNoticeRequest;
 import com.redbox.domain.notice.entity.Notice;
 import com.redbox.domain.notice.exception.NoticeNotFoundException;
 import com.redbox.domain.notice.repository.NoticeQueryRepository;
@@ -46,20 +45,17 @@ public class NoticeService {
         noticeRepository.increaseHit(noticeId);
 
         // 공지사항 조회
-        Notice notice = noticeRepository.findWithAttachFilesById(noticeId)
+        Notice notice = noticeRepository.findForDetail(noticeId)
                 .orElseThrow(NoticeNotFoundException::new);
 
-        // 글쓴이 조회
-        String writer = getWriter(notice);
-
-        return new NoticeResponse(notice, writer);
+        return new NoticeResponse(notice);
     }
 
     @Transactional
     public NoticeResponse createNotice(CreateNoticeRequest request, List<MultipartFile> files) {
         Notice notice = Notice.builder()
                 // 로그인 구현 되면 추가
-//                .userId()
+//                .user()
                 .noticeTitle(request.getTitle())
                 .noticeContent(request.getContent())
                 .build();
@@ -86,16 +82,15 @@ public class NoticeService {
             }
         }
 
-        // 글쓴이
-        String writer = getWriter(notice);
-
-        return new NoticeResponse(notice, writer);
+        return new NoticeResponse(notice);
     }
 
-    private String getWriter(Notice notice) {
-        return userRepository.findNameById(notice.getUserId())
-                .orElse("Unknown");
+    @Transactional
+    public NoticeResponse updateNotice(Long noticeId, UpdateNoticeRequest request) {
+        Notice notice = noticeRepository.findForUpdate(noticeId)
+                .orElseThrow(NoticeNotFoundException::new);
+        notice.updateNotice(request);
+
+        return new NoticeResponse(notice);
     }
-
-
 }

--- a/backend/src/main/java/com/redbox/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/redbox/domain/user/repository/UserRepository.java
@@ -2,10 +2,16 @@ package com.redbox.domain.user.repository;
 
 import com.redbox.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    @Query("SELECT u.name FROM User u WHERE u.id = :userId")
+    Optional<String> findNameById(Long userId);
 }

--- a/backend/src/main/java/com/redbox/global/config/S3Config.java
+++ b/backend/src/main/java/com/redbox/global/config/S3Config.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -23,6 +24,16 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(accessKey, secretKey)

--- a/backend/src/main/java/com/redbox/global/config/S3Config.java
+++ b/backend/src/main/java/com/redbox/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.redbox.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/redbox/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/redbox/global/exception/ErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    // 공지사항 관련
+    FAIL_TO_FIND_NOTICE(HttpStatus.NOT_FOUND,"해당 공지사항을 찾을 수 없습니다."),
+
     // 첨부파일 관련
     INVALID_ATTACHFILE(HttpStatus.BAD_REQUEST, "첨부파일이 비어있습니다."),
 

--- a/backend/src/main/java/com/redbox/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/redbox/global/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
 
     // 첨부파일 관련
     INVALID_ATTACHFILE(HttpStatus.BAD_REQUEST, "첨부파일이 비어있습니다."),
+    FAIL_TO_FIND_ATTACHFILE(HttpStatus.NOT_FOUND,"첨부파일을 찾을 수 없습니다."),
+    NOT_BELONG_TO_FILE(HttpStatus.BAD_REQUEST, "파일이 해당 게시글에 속하지 않습니다"),
 
     // 헌혈 기사 관련
     FAIL_TO_FIND_ARTICLE(HttpStatus.NOT_FOUND,"해당 기사를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/redbox/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/redbox/global/exception/ErrorCode.java
@@ -7,9 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    // 첨부파일 관련
+    INVALID_ATTACHFILE(HttpStatus.BAD_REQUEST, "첨부파일이 비어있습니다."),
 
     // 헌혈 기사 관련
-    FAILED_TO_FIND_ARTICLE(HttpStatus.NOT_FOUND,"해당 기사를 찾을 수 없습니다."),
+    FAIL_TO_FIND_ARTICLE(HttpStatus.NOT_FOUND,"해당 기사를 찾을 수 없습니다."),
 
     // 회원 가입 관련
     UNVERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),

--- a/backend/src/main/java/com/redbox/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/redbox/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.redbox.global.exception;
 
 import com.redbox.global.infra.s3.S3Exception;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -69,5 +71,16 @@ public class GlobalExceptionHandler {
                         "파일 처리 중 오류가 발생했습니다.",
                         HttpStatus.INTERNAL_SERVER_ERROR.toString()
                 ));
+    }
+
+    // 시스템 관련 에러 처리
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
+        log.error("System Error occurred: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(
+                        "시스템 오류가 발생했습니다",
+                        "SYSTEM_ERROR"));
     }
 }

--- a/backend/src/main/java/com/redbox/global/infra/s3/S3Exception.java
+++ b/backend/src/main/java/com/redbox/global/infra/s3/S3Exception.java
@@ -1,0 +1,7 @@
+package com.redbox.global.infra.s3;
+
+public class S3Exception extends RuntimeException {
+    public S3Exception(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/redbox/global/infra/s3/S3Service.java
+++ b/backend/src/main/java/com/redbox/global/infra/s3/S3Service.java
@@ -8,6 +8,8 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -49,17 +51,39 @@ public class S3Service {
                 .build();
 
         s3Client.deleteObject(request);
+
+        // 빈 디렉토리 확인 후 삭제
+        deleteDirectory(category, id);
+    }
+
+    public void deleteDirectory(Category category, Long id) {
+        try {
+            // 해당 디렉토리의 prefix로 모든 객체 나열
+            String prefix = category.getPath() + "/" + id + "/";
+
+            ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .prefix(prefix)
+                    .build();
+
+            ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+
+            // 객체가 없다면 디렉토리도 삭제
+            if (listResponse.contents().isEmpty()) {
+                DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(prefix)
+                        .build();
+
+                s3Client.deleteObject(deleteRequest);
+            }
+        } catch (Exception e) {
+            throw new S3Exception("Error while deleting directory", e);
+        }
     }
 
     private static String getKey(Category category, Long id, String fileName) {
-        String key = "";
-        if (category == Category.NOTICE) {
-            key = String.format("notice/%d/%s", id, fileName);
-        } else if (category == Category.REQUEST){
-            key = String.format("request/%d/%s", id, fileName);
-        }
-
-        return key;
+        return String.format("%s/%d/%s", category.getPath(), id, fileName);
     }
 
     public String generatePresignedUrl(Category category, Long id, String fileName, String originalFilename) {

--- a/backend/src/main/java/com/redbox/global/infra/s3/S3Service.java
+++ b/backend/src/main/java/com/redbox/global/infra/s3/S3Service.java
@@ -1,0 +1,64 @@
+package com.redbox.global.infra.s3;
+
+import com.redbox.domain.attach.entity.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile file, Category category, Long id, String fileName) {
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(getKey(category, id, fileName))
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(request,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                    bucket, region, getKey(category, id, fileName));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void deleteFile(Category category, Long id, String fileName) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(getKey(category, id, fileName))
+                .build();
+
+        s3Client.deleteObject(request);
+    }
+
+    private static String getKey(Category category, Long id, String fileName) {
+        String key = "";
+        if (category == Category.NOTICE) {
+            key = String.format("notice/%d/%s", id, fileName);
+        } else if (category == Category.REQUEST){
+            key = String.format("request/%d/%s", id, fileName);
+        }
+
+        return key;
+    }
+}

--- a/backend/src/main/java/com/redbox/global/util/FileUtils.java
+++ b/backend/src/main/java/com/redbox/global/util/FileUtils.java
@@ -1,0 +1,24 @@
+package com.redbox.global.util;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+public class FileUtils {
+
+    public static String generateNewFilename() {
+        LocalDateTime now = LocalDateTime.now();
+        String datePart = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uniquePart = UUID.randomUUID().toString().substring(0, 13).toUpperCase().replace("-", "");
+
+
+        return String.format("%s_%s", datePart, uniquePart);
+    }
+
+    public static String getExtension(MultipartFile file) {
+        return StringUtils.getFilenameExtension(file.getOriginalFilename());
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,10 +41,26 @@ spring:
       port: ${REDIS_PORT}
       host: ${REDIS_HOST}
       password: ${REDIS_PASSWORD}
+  servlet:
+    multipart:
+      max-file-size: 10MB        # 단일 파일 최대 크기
+      max-request-size: 50MB     # 요청당 전체 파일 크기
+      enabled: true
 logging:
   level:
     root: INFO
     org.springframework.security: DEBUG
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
 ---
 spring:
   config:


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
1.  공지사항메뉴에서 사용되는 CRUD 기능 구현했습니다.
2. 첨부파일을 S3 스토리지을 활용하고자 해당 기능 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1.  공지사항 처음 글 등록시 공지사항의 내용과 첨부파일을 한번에 저장합니다.
2. 공지사항 수정시 공지사항에 대한 내용 첨부파일에 대한 내용 따로 컨트롤합니다.
3. 화면 상 하나의 첨부파일만 받고있는데, 여러 파일을 받을 수 있도록 수정되어야 합니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
