### PR TITLE
최근 공지사항 5개 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
+++ b/backend/src/main/java/com/redbox/domain/notice/controller/NoticeController.java
@@ -3,10 +3,7 @@ package com.redbox.domain.notice.controller;
 import com.redbox.domain.attach.dto.AttachFileResponse;
 import com.redbox.domain.attach.entity.Category;
 import com.redbox.domain.attach.service.AttachFileService;
-import com.redbox.domain.notice.dto.CreateNoticeRequest;
-import com.redbox.domain.notice.dto.NoticeListResponse;
-import com.redbox.domain.notice.dto.NoticeResponse;
-import com.redbox.domain.notice.dto.UpdateNoticeRequest;
+import com.redbox.domain.notice.dto.*;
 import com.redbox.domain.notice.service.NoticeService;
 import com.redbox.global.entity.PageResponse;
 import jakarta.validation.Valid;
@@ -94,5 +91,10 @@ public class NoticeController {
             @PathVariable Long fileId) {
         attachFileService.removeFile(Category.NOTICE, noticeId, fileId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/notices/top5")
+    public ResponseEntity<List<RecentNoticeResponse>> getTop5Notices() {
+        return ResponseEntity.ok(noticeService.getTop5Notices());
     }
 }

--- a/backend/src/main/java/com/redbox/domain/notice/dto/RecentNoticeResponse.java
+++ b/backend/src/main/java/com/redbox/domain/notice/dto/RecentNoticeResponse.java
@@ -1,0 +1,19 @@
+package com.redbox.domain.notice.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class RecentNoticeResponse {
+
+    private Long noticeNo;
+    private String title;
+    private LocalDate createdDate;
+
+    public RecentNoticeResponse(Long noticeNo, String title, LocalDate createdDate) {
+        this.noticeNo = noticeNo;
+        this.title = title;
+        this.createdDate = createdDate;
+    }
+}

--- a/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/redbox/domain/notice/repository/NoticeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -31,4 +32,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             " left join fetch n.attachFiles af" +
             " where n.id = :noticeId")
     Optional<Notice> findForDelete(@Param("noticeId") Long id);
+
+    List<Notice> findTop5ByOrderByCreatedAtDesc();
 }

--- a/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/redbox/domain/notice/service/NoticeService.java
@@ -3,10 +3,7 @@ package com.redbox.domain.notice.service;
 import com.redbox.domain.attach.entity.AttachFile;
 import com.redbox.domain.attach.entity.Category;
 import com.redbox.domain.attach.repository.AttachFileRepository;
-import com.redbox.domain.notice.dto.CreateNoticeRequest;
-import com.redbox.domain.notice.dto.NoticeListResponse;
-import com.redbox.domain.notice.dto.NoticeResponse;
-import com.redbox.domain.notice.dto.UpdateNoticeRequest;
+import com.redbox.domain.notice.dto.*;
 import com.redbox.domain.notice.entity.Notice;
 import com.redbox.domain.notice.exception.NoticeNotFoundException;
 import com.redbox.domain.notice.repository.NoticeQueryRepository;
@@ -23,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -105,5 +103,16 @@ public class NoticeService {
         }
 
         noticeRepository.delete(notice);
+    }
+
+    // 최신순 공지사항 5개 조회
+    public List<RecentNoticeResponse> getTop5Notices() {
+        return noticeRepository.findTop5ByOrderByCreatedAtDesc().stream()
+                .map(notice -> new RecentNoticeResponse(
+                        notice.getId(),
+                        notice.getNoticeTitle(),
+                        notice.getCreatedAt().toLocalDate()
+                ))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
최근 공지사항 5개를 조회하는 API를 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
Commit: feat: 최근 공지사항 5개 조회 API 추가 (RB-167)
- 공지사항 조회 컨트롤러 구현
 - NoticeController.getTop5Notices() 메서드 추가.
 - /notices/top5 엔드포인트에서 최신 공지사항 5개를 조회하도록 설정.

- Repository 메서드 추가
 - 공지사항을 생성일 기준 내림차순으로 5개 조회하는 findTop5ByOrderByCreatedAtDesc() 메서드를 NoticeRepository에 구현.
Service 메서드 구현

비즈니스 로직 처리 및 Notice 엔티티를 RecentNoticeResponse DTO로 매핑하는 NoticeService.getTop5Notices() 메서드 추가.
공지사항 데이터를 리스트로 반환.
DTO 설계

공지사항의 ID, 제목, 생성일을 포함하는 응답 데이터를 위한 RecentNoticeResponse DTO 추가.
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
