### PR TITLE
feat: 대시보드 조회에 진행 중인 요청 게시글 수 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/redbox/domain/dashboard/dto/DonationStats.java
+++ b/backend/src/main/java/com/redbox/domain/dashboard/dto/DonationStats.java
@@ -12,5 +12,6 @@ public class DonationStats {
     private int patientsHelped;    // 도움을 준 사람 수
     private String grade;
     private LocalDate lastDonationDate;
+    private int inProgressRequests;     // 진행 중인 요청 게시글 수
 
 }

--- a/backend/src/main/java/com/redbox/domain/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/redbox/domain/dashboard/service/DashboardService.java
@@ -3,6 +3,7 @@ package com.redbox.domain.dashboard.service;
 import com.redbox.domain.dashboard.dto.DashboardResponse;
 import com.redbox.domain.dashboard.dto.UserInfo;
 import com.redbox.domain.dashboard.dto.DonationStats;
+import com.redbox.domain.request.repository.RequestRepository;
 import com.redbox.domain.user.entity.User;
 import com.redbox.domain.user.service.UserService;
 import com.redbox.domain.donation.application.DonationStatsService;
@@ -17,6 +18,7 @@ public class DashboardService {
 
     private final UserService userService;
     private final DonationStatsService donationStatsService;
+    private final RequestRepository requestRepository;
 
     public DashboardResponse getDashboardData() {
         // 1. 사용자 정보 조회
@@ -34,11 +36,14 @@ public class DashboardService {
         int patientsHelped = donationStatsService.getPatientsHelped(userId);
         LocalDate lastDonationDate = donationStatsService.getLastDonationDate(userId);
 
-        // 3. 등급 계산
+        // 3. 진행 중인 요청 게시글 수 조회
+        int inProgressRequests = requestRepository.countInProgressRequestsByUserId(userId);
+
+        // 4. 등급 계산
         String grade = calculateGrade(totalDonatedCards);
 
-        // 4. 대시보드 응답 생성
-        DonationStats donationStats = new DonationStats(totalDonatedCards, patientsHelped, grade, lastDonationDate);
+        // 5. 대시보드 응답 생성
+        DonationStats donationStats = new DonationStats(totalDonatedCards, patientsHelped, grade, lastDonationDate, inProgressRequests);
         return new DashboardResponse(userInfo, donationStats);
     }
 

--- a/backend/src/main/java/com/redbox/domain/request/repository/RequestRepository.java
+++ b/backend/src/main/java/com/redbox/domain/request/repository/RequestRepository.java
@@ -3,11 +3,16 @@ package com.redbox.domain.request.repository;
 import com.redbox.domain.request.entity.Request;
 import com.redbox.domain.request.entity.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface RequestRepository extends JpaRepository<Request, Long>, RequestRepositoryCustom {
     List<Request> findByRequestStatus(RequestStatus requestStatus);
+
     List<Request> findByDonationEndDateBeforeAndProgressNot(LocalDate date, RequestStatus progress);
+
+    @Query("SELECT COUNT(r) FROM Request r WHERE r.userId = :userId AND r.requestStatus = 'APPROVE' AND r.progress = 'IN_PROGRESS'")
+    int countInProgressRequestsByUserId(Long userId);
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
대시보드 조회 API에 진행 중인 요청 게시글 수를 조회하는 기능을 추가했습니다. 
사용자의 요청 게시글 중 승인(APPROVE) 상태이면서 진행 중(IN_PROGRESS) 상태인 게시글의 개수를 조회하여 응답 데이터에 포함합니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. **DashboardService**  
   - 진행 중인 요청 게시글 수를 조회하는 로직 추가.
   - RequestRepository의 `countInProgressRequestsByUserId` 메서드를 호출하여 해당 데이터를 조회.
   - DonationStats DTO에 진행 중인 요청 게시글 수(inProgressRequests)를 포함하여 대시보드 응답 생성.

2. **DonationStats DTO**  
   - 진행 중인 요청 게시글 수를 나타내는 `inProgressRequests` 필드 추가.

3. **RequestRepository**  
   - 사용자 ID와 요청 상태(APPROVE), 진행 상태(IN_PROGRESS)를 기준으로 요청 게시글 수를 조회하는 `countInProgressRequestsByUserId` 쿼리 추가.