### PR TITLE
feat: 레드박스 통계 조회에 진행 중인 요청 게시글 수 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/redbox/domain/redbox/applicaction/RedboxService.java
+++ b/backend/src/main/java/com/redbox/domain/redbox/applicaction/RedboxService.java
@@ -12,6 +12,7 @@ import com.redbox.domain.redbox.repository.RedboxRepository;
 import com.redbox.domain.redcard.entity.Redcard;
 import com.redbox.domain.redcard.repository.RedcardRepository;
 import com.redbox.domain.redcard.service.RedcardService;
+import com.redbox.domain.request.repository.RequestRepository;
 import com.redbox.domain.user.service.UserService;
 import com.redbox.domain.redbox.exception.RedboxNotFoundException;
 
@@ -24,13 +25,15 @@ import java.util.List;
 public class RedboxService extends AbstractDonationService {
 
     private final RedboxRepository redboxRepository;
+    private final RequestRepository requestRepository;
 
     public RedboxService(UserService userService,
                          RedcardRepository redcardRepository,
                          RedboxRepository redboxRepository,
-                         RedcardService redcardService, DonationGroupRepository donationGroupRepository, DonationDetailRepository donationDetailRepository) {
+                         RedcardService redcardService, DonationGroupRepository donationGroupRepository, DonationDetailRepository donationDetailRepository, RequestRepository requestRepository) {
         super(userService, redcardRepository, redcardService, donationGroupRepository, donationDetailRepository); // 부모 클래스 생성자 호출
         this.redboxRepository = redboxRepository;
+        this.requestRepository = requestRepository;
     }
 
     public RedboxStatsResponse getRedboxStats() {
@@ -44,7 +47,10 @@ public class RedboxService extends AbstractDonationService {
         Integer helpedPatients = donationGroupRepository.getHelpedPatientsCount();
         helpedPatients = (helpedPatients != null) ? helpedPatients : 0;
 
-        return new RedboxStatsResponse(totalDonatedCards, helpedPatients);
+        // 진행 중인 요청 게시글 수 조회
+        int inProgressRequests = requestRepository.countAllInProgressRequests();
+
+        return new RedboxStatsResponse(totalDonatedCards, helpedPatients, inProgressRequests);
     }
 
     @Override

--- a/backend/src/main/java/com/redbox/domain/redbox/dto/RedboxStatsResponse.java
+++ b/backend/src/main/java/com/redbox/domain/redbox/dto/RedboxStatsResponse.java
@@ -8,4 +8,6 @@ import lombok.Getter;
 public class RedboxStatsResponse {
     private int totalDonatedCards;  // 헌혈증 누적 개수
     private int totalPatientsHelped;    // 도움을 받은 환자 수
+    private int inProgressRequests; // 진행 중인 요청 게시글 수
+
 }

--- a/backend/src/main/java/com/redbox/domain/request/repository/RequestRepository.java
+++ b/backend/src/main/java/com/redbox/domain/request/repository/RequestRepository.java
@@ -15,4 +15,7 @@ public interface RequestRepository extends JpaRepository<Request, Long>, Request
 
     @Query("SELECT COUNT(r) FROM Request r WHERE r.userId = :userId AND r.requestStatus = 'APPROVE' AND r.progress = 'IN_PROGRESS'")
     int countInProgressRequestsByUserId(Long userId);
+
+    @Query("SELECT COUNT(r) FROM Request r WHERE r.requestStatus = 'APPROVE' AND r.progress = 'IN_PROGRESS'")
+    int countAllInProgressRequests();
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
레드박스 통계 조회 API에 진행 중인 요청 게시글 수를 조회하는 기능을 추가하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. **RequestRepository에 진행 중인 요청 게시글 수 조회 메서드 추가**
   - countInProgressRequests() 메서드를 추가하여 승인 및 진행 중 상태의 요청 게시글 수를 조회.

2. **RedboxService에 기능 통합**
   - getRedboxStats() 메서드에서 진행 중인 요청 게시글 수를 조회하여 RedboxStatsResponse에 포함.

3. **RedboxStatsResponse 수정**
   - 진행 중인 요청 게시글 수(inProgressRequests) 필드를 추가.