### PR TITLE
feat: DonatePage에 레드박스 통계 조회 API 연동 및 버튼 스타일 수정

### DIFF
--- a/frontend/src/pages/DonatePage.jsx
+++ b/frontend/src/pages/DonatePage.jsx
@@ -6,19 +6,23 @@ import RedboxDonationModal from "../components/RedboxDonationModal";
 
 const DonatePage = () => {
   const navigate = useNavigate();
-  const [data, setData] = useState({});
+  const [data, setData] = useState({
+    totalDonatedCards: 0,
+    totalPatientsHelped: 0,
+    inProgressRequests: 0,
+  });
   const [isMemberModalOpen, setIsMemberModalOpen] = useState(false);
   const [isRedboxModalOpen, setIsRedboxModalOpen] = useState(false);
   const [donationType, setDonationType] = useState("");
 
-  const handleSubmit = async ( quantity, comment, userId = null) => {
+  const handleSubmit = async (quantity, comment, userId = null) => {
     try {
-      const response = await api.post(`/donate/${donationType}`, {
+      await api.post(`/donate/${donationType}`, {
         userId,
         quantity,
         comment,
       });
-      alert("기부 성공")
+      alert("기부 성공");
     } catch (error) {
       console.error("기부 오류:", error);
       alert("기부 실패");
@@ -26,21 +30,20 @@ const DonatePage = () => {
     setIsMemberModalOpen(false);
     setIsRedboxModalOpen(false);
   };
-  
-  const fetchData = async() => {
+
+  const fetchData = async () => {
     try {
-      const response = await fetch(url);
-      const result = await response.json();
-      setData(result);
-    } catch(error) {
-      console.error("데이터를 가져오는 중 오류 발생 : ", error)
+      const response = await api.get("/redbox/stats");
+      setData(response.data);
+    } catch (error) {
+      console.error("데이터를 가져오는 중 오류 발생:", error);
+      alert("레드박스 데이터를 불러오는 데 문제가 발생했습니다.");
     }
   };
 
   useEffect(() => {
-    fetchData(); // 컴포넌트 마운트 시 데이터 가져오기
+    fetchData();
   }, []);
-
 
   return (
     <main className="flex-grow">
@@ -54,60 +57,92 @@ const DonatePage = () => {
             <p className="text-gray-600 text-3xl mt-15 mb-20">
               당신의 작은 기부가 누군가에게는 큰 희망이 됩니다
             </p>
-            <button className="bg-green-500 hover:bg-pink-500 transition-colors rounded-lg mr-8"
-              onClick={() => {
-                setDonationType("redbox")
-                setIsRedboxModalOpen(true)
-              }}
-            >
-              <img src="/src/assets/image.png" alt="레드 박스" className="w-25 h-25" />
-              레드박스 기부하기
-            </button>
-            <button className="bg-yellow-500 hover:bg-blue-500 transition-colors rounded-lg ml-8"
-              onClick={() => {
-                setDonationType("user")
-                setIsMemberModalOpen(true)
-              }}
-            >
-              <img src="/src/assets/image.png" alt="레드 박스" className="w-25 h-25" />
-              개인에게 기부하기
-            </button>
+            <div className="flex justify-center space-x-8">
+              <button
+                className="bg-white border border-gray-300 hover:border-red-500 hover:text-red-600 transition-all text-gray-700 rounded-lg px-6 py-3 flex items-center justify-center shadow-md"
+                onClick={() => {
+                  setDonationType("redbox");
+                  setIsRedboxModalOpen(true);
+                }}
+              >
+                <img
+                  src="/src/assets/image.png"
+                  alt="레드 박스"
+                  className="w-12 h-12 mr-2"
+                />
+                레드박스 기부하기
+              </button>
+              <button
+                className="bg-white border border-gray-300 hover:border-orange-500 hover:text-orange-500 transition-all text-gray-700 rounded-lg px-6 py-3 flex items-center justify-center shadow-md"
+                onClick={() => {
+                  setDonationType("user");
+                  setIsMemberModalOpen(true);
+                }}
+              >
+                <img
+                  src="/src/assets/image.png"
+                  alt="개인 기부"
+                  className="w-12 h-12 mr-2"
+                />
+                개인에게 기부하기
+              </button>
+            </div>
           </div>
         </div>
-
-            
       </section>
 
       {/* Stats Section */}
-      <section className="py-16">
-        <div className="max-w-6xl mx-auto px-6">
-          <div className="grid grid-cols-3 gap-8 text-center">
-            <div className="p-6 bg-gray-50 rounded-lg">
-              <p className="text-3xl font-bold text-red-600 mb-2">{data.cnt_donate} 명</p>
-              <p className="text-gray-600">현재까지 기부된 현혈증</p>
-            </div>
-            <div className="p-6 bg-gray-50 rounded-lg">
-              <p className="text-3xl font-bold text-red-600 mb-2">{data.cnt_receive_users} 명</p>
-              <p className="text-gray-600">도움을 받은 환자</p>
-            </div>
-            <div className="p-6 bg-gray-50 rounded-lg">
-              <p className="text-3xl font-bold text-red-600 mb-2">{data.cnt_articles} 건</p>
-              <button className="text-gray-600 hover:text-black" onClick={()=>{navigate("/community/request")}}>진행중인 기부 요청 확인하기</button>
-            </div>
-          </div>
-        </div>
-      </section>
+<section className="py-16">
+  <div className="max-w-6xl mx-auto px-6">
+    <div className="text-center mb-12">
+      <h3 className="text-4xl font-bold text-red-600">
+        레드박스 통계
+      </h3>
+      <p className="text-gray-600 text-xl mt-4">
+        진행중인 레드박스 기부 현황과 요청 건수를 확인해보세요.
+      </p>
+    </div>
+    <div className="grid grid-cols-3 gap-8 text-center">
+      {/* 총 기부된 헌혈증 */}
+      <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
+        <p className="text-4xl font-bold text-red-600 mb-2">
+          {data.totalDonatedCards} 개
+        </p>
+        <p className="text-gray-600 text-lg">레드박스에 기부된 헌혈증</p>
+      </div>
+      {/* 도움을 받은 환자 */}
+      <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
+        <p className="text-4xl font-bold text-red-600 mb-2">
+          {data.totalPatientsHelped} 명
+        </p>
+        <p className="text-gray-600 text-lg">레드박스를 통해 도움받은 환자</p>
+      </div>
+      {/* 진행 중인 기부 요청 */}
+      <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
+        <p className="text-4xl font-bold text-red-600 mb-2">
+          {data.inProgressRequests} 건
+        </p>
+        <button
+          className="text-gray-600 text-lg hover:text-black"
+          onClick={() => navigate("/community/request")}
+        >
+          진행 중인 요청 확인하기
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
       {/* 모달 컴포넌트 */}
       {isMemberModalOpen && (
         <MemberDonationModal
-          setDonationType
           onClose={() => setIsMemberModalOpen(false)}
           onSubmit={handleSubmit}
         />
       )}
       {isRedboxModalOpen && (
         <RedboxDonationModal
-          setDonationType
           onClose={() => setIsRedboxModalOpen(false)}
           onSubmit={handleSubmit}
         />


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
레드박스 기부 페이지(DonatePage)에 기부 통계 조회 기능을 연동하고, 버튼 스타일을 개선했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 레드박스 통계 조회 API 연동
   - `/redbox/stats` API를 호출하여 레드박스 통계 데이터(기부된 헌혈증 수, 도움받은 환자 수, 진행 중인 기부 요청 수)를 가져와 화면에 표시.
   - 통계 데이터가 없을 경우 기본값(0)으로 초기화.

- 버튼 스타일 수정
   - 버튼 배경을 흰색으로 변경하고 테두리를 추가하여 더 깔끔한 디자인 적용.
   - 레드박스 기부 버튼: 테두리와 텍스트 컬러를 빨간색으로 설정.
   - 개인 기부 버튼: 테두리와 텍스트 컬러를 주황색으로 설정.
   - 버튼에 호버 효과와 그림자 추가로 강조.