### PR TITLE
feat: 대시보드 조회 API 연동

### DIFF
--- a/frontend/src/pages/mypage/DashboardPage.jsx
+++ b/frontend/src/pages/mypage/DashboardPage.jsx
@@ -1,4 +1,6 @@
+import { useState, useEffect } from "react";
 import MyPageSideBar from "../../components/wrapper/MyPageSideBar";
+import api from "../../lib/axios";
 import {
   User,
   Calendar,
@@ -10,56 +12,81 @@ import {
 } from "lucide-react";
 
 const DashboardPage = () => {
+  const [dashboardData, setDashboardData] = useState({
+    userInfo: {
+      name: "",
+      birth: "",
+      gender: "",
+      phoneNumber: "",
+    },
+    donationStats: {
+      totalDonatedCards: 0,
+      patientsHelped: 0,
+      grade: "",
+      lastDonationDate: "",
+      inProgressRequests: 0,
+    },
+  });
+
+  const fetchDashboardData = async () => {
+    try {
+      const response = await api.get("/dashboard");
+      setDashboardData(response.data);
+    } catch (error) {
+      console.error("대시보드 데이터를 불러오는 중 오류 발생:", error);
+    }
+  };
+
+  useEffect(() => {
+    fetchDashboardData();
+  }, []);
+
+  const { userInfo, donationStats } = dashboardData;
+
+  const formatGender = (gender) => {
+    if (gender === "MALE") return "남";
+    if (gender === "FEMALE") return "여";
+    return "N/A";
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="flex h-full">
         <MyPageSideBar />
         <div className="flex-1 p-8">
           <div className="bg-white rounded-lg shadow-sm p-8 h-full">
-            {/* Main Content Section */}
             <div className="space-y-8">
               {/* Profile and Grade Section */}
               <div className="grid grid-cols-12 gap-12">
-                {/* Left Side - Profile Info */}
                 <div className="col-span-9 space-y-4">
                   <div className="flex items-center space-x-4 bg-gray-50 p-4 rounded-lg">
                     <User className="text-gray-400" />
                     <span className="text-gray-600">성 명:</span>
-                    <span className="font-medium">홍길동</span>
+                    <span className="font-medium">{userInfo.name || "N/A"}</span>
                   </div>
-
                   <div className="flex items-center space-x-4 bg-gray-50 p-4 rounded-lg">
                     <Calendar className="text-gray-400" />
                     <span className="text-gray-600">생년월일:</span>
-                    <span>1990.01.01</span>
+                    <span>{userInfo.birth || "N/A"}</span>
                   </div>
-
                   <div className="flex items-center space-x-4 bg-gray-50 p-4 rounded-lg">
                     <User className="text-gray-400" />
                     <span className="text-gray-600">성 별:</span>
-                    <span>여</span>
+                    <span>{formatGender(userInfo.gender)}</span>
                   </div>
-
                   <div className="flex items-center space-x-4 bg-gray-50 p-4 rounded-lg">
                     <Phone className="text-gray-400" />
                     <span className="text-gray-600">연락처:</span>
-                    <span>010-5555-9999</span>
+                    <span>{userInfo.phoneNumber || "N/A"}</span>
                   </div>
-
                   <div className="flex items-center space-x-4 bg-gray-50 p-4 rounded-lg">
                     <Clock className="text-gray-400" />
                     <span className="text-gray-600">최근 기부일자:</span>
-                    <span>2024.03.15</span>
-                  </div>
-
-                  <div className="flex items-center space-x-4 bg-gray-50 p-4 rounded-lg">
-                    <Clock className="text-gray-400" />
-                    <span className="text-gray-600">최근 헌혈일자:</span>
-                    <span>2024.03.15</span>
+                    <span>
+                      {donationStats.lastDonationDate || "N/A"}
+                    </span>
                   </div>
                 </div>
-
-                {/* Right Side - Grade Badge */}
                 <div className="col-span-3 flex items-center justify-center">
                   <div className="text-center">
                     <div className="relative">
@@ -67,13 +94,15 @@ const DashboardPage = () => {
                         <div className="text-center">
                           <Award className="w-8 h-8 text-red-500 mx-auto mb-2" />
                           <h3 className="text-xl font-bold text-red-500">
-                            VIP
+                            {donationStats.grade || "N/A"}
                           </h3>
                           <p className="text-sm text-gray-500">헌혈 전문가</p>
                         </div>
                       </div>
                       <div className="absolute -top-2 -right-2 w-10 h-10 bg-yellow-400 rounded-full flex items-center justify-center">
-                        <span className="text-white font-bold text-sm">A+</span>
+                        <span className="text-white font-bold text-sm">
+                          {donationStats.totalDonatedCards}
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -86,35 +115,30 @@ const DashboardPage = () => {
                   <div className="flex justify-between items-center mb-4">
                     <Heart className="w-6 h-6 text-red-500" />
                     <span className="text-2xl font-bold text-red-500">
-                      1,234
+                      {donationStats.totalDonatedCards}
                     </span>
                   </div>
                   <p className="text-gray-600 text-sm">
-                    현재까지 기부된 현혈증
-                  </p>
-                  <p className="text-red-400 text-xs mt-2">
-                    +12% from last month
+                    현재까지 기부한 헌혈증
                   </p>
                 </div>
-
                 <div className="bg-red-50 p-6 rounded-xl">
                   <div className="flex justify-between items-center mb-4">
                     <Users className="w-6 h-6 text-red-500" />
-                    <span className="text-2xl font-bold text-red-500">567</span>
+                    <span className="text-2xl font-bold text-red-500">
+                      {donationStats.patientsHelped}
+                    </span>
                   </div>
                   <p className="text-gray-600 text-sm">도움을 받은 환자</p>
-                  <p className="text-red-400 text-xs mt-2">
-                    +5% from last month
-                  </p>
                 </div>
-
                 <div className="bg-red-50 p-6 rounded-xl">
                   <div className="flex justify-between items-center mb-4">
                     <Clock className="w-6 h-6 text-red-500" />
-                    <span className="text-2xl font-bold text-red-500">89</span>
+                    <span className="text-2xl font-bold text-red-500">
+                      {donationStats.inProgressRequests}
+                    </span>
                   </div>
                   <p className="text-gray-600 text-sm">진행중인 기부 요청</p>
-                  <p className="text-red-400 text-xs mt-2">+3 new requests</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 📌 과제 설명
대시보드 페이지에서 사용자 정보와 기부 통계를 표시하기 위해 /dashboard API를 연동했습니다.

## 👩‍💻 요구 사항과 구현 내용
- `/dashboard` API를 연동하여 사용자 정보 및 기부 통계 데이터를 동적으로 표시.
- 사용자 정보(이름, 생년월일, 성별, 연락처, 최근 기부일자)와 기부 통계(기부된 헌혈증 수, 도움받은 환자 수, 진행 중인 기부 요청 수)를 UI에 표시.
- 성별 데이터를 "남" / "여" 형식으로 변환 처리.