### PR TITLE
fix: 드롭다운 메뉴 z-index 문제 해결

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -101,7 +101,7 @@ const Header = () => {
                   <ChevronDown size={16} />
                 </button>
 
-                <div className="invisible group-hover:visible absolute left-0 w-48 bg-white text-black rounded-md shadow-lg">
+                <div className="invisible group-hover:visible absolute left-0 w-48 bg-white text-black rounded-md shadow-lg z-50">
                   <div className="py-1">
                     <Link
                       to="/mypage/dashboard"


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
드롭다운 메뉴가 다른 요소 뒤로 표시되는 문제를 해결하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- `z-index` 조정을 통해 드롭다운 메뉴가 항상 최상단에 표시되도록 설정 (`z-50` 적용).
- 
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
